### PR TITLE
Fix *Reset to default* to work with boolean/checkboxes (#191)

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -173,10 +173,13 @@ class ConstanceAdmin(admin.ModelAdmin):
         config_value = {
             'name': name,
             'default': localize(default),
+            'raw_default': default,
             'help_text': _(help_text),
             'value': localize(value),
             'modified': localize(value) != localize(default),
             'form_field': form[name],
+            'is_checkbox': isinstance(
+                form[name].field.widget, forms.CheckboxInput),
         }
 
         return config_value

--- a/constance/templates/admin/constance/includes/results_list.html
+++ b/constance/templates/admin/constance/includes/results_list.html
@@ -20,7 +20,10 @@
             {{ item.form_field.errors }}
             {{ item.form_field }}
             <br>
-            <a href="#" onClick="document.getElementById('{{ item.form_field.auto_id }}').value = '{{ item.default|escapejs }}'; return false;">Reset to default</a>
+            <a href="#" onClick="
+              document.getElementById('{{ item.form_field.auto_id }}').{% if item.is_checkbox %}checked =
+                  {% if item.raw_default %} true {% else %} false {% endif %}
+                {% else %}value = '{{ item.default|escapejs }}'{% endif %}; return false;">Reset to default</a>
         </td>
         <td>
             {% if item.modified %}


### PR DESCRIPTION
* Fix *Reset to default* to work with boolean/checkboxes

* Add field name to each config value
* Check field name and use *checked* for checkbox and *value* otherwise

Fix #189

* Add and use raw_default and is_checkbox